### PR TITLE
support SVG >=10MB

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -2,7 +2,7 @@
 
 #include "lang.h"
 
-int load_image_buffer(void *buf, size_t len, int imageType, VipsImage **out) {
+int load_image_buffer(void *buf, size_t len, int imageType, gboolean unlimitedSvgSize, VipsImage **out) {
   int code = 1;
 
   if (imageType == JPEG) {
@@ -18,7 +18,7 @@ int load_image_buffer(void *buf, size_t len, int imageType, VipsImage **out) {
   } else if (imageType == PDF) {
     code = vips_pdfload_buffer(buf, len, out, NULL);
   } else if (imageType == SVG) {
-    code = vips_svgload_buffer(buf, len, out,  "unlimited", TRUE, NULL);
+    code = vips_svgload_buffer(buf, len, out,  "unlimited", unlimitedSvgSize, NULL);
   } else if (imageType == HEIF) {
     // added autorotate on load as currently it addresses orientation issues
     // https://github.com/libvips/libvips/pull/1680

--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -18,7 +18,7 @@ int load_image_buffer(void *buf, size_t len, int imageType, VipsImage **out) {
   } else if (imageType == PDF) {
     code = vips_pdfload_buffer(buf, len, out, NULL);
   } else if (imageType == SVG) {
-    code = vips_svgload_buffer(buf, len, out, NULL);
+    code = vips_svgload_buffer(buf, len, out,  "unlimited", TRUE, NULL);
   } else if (imageType == HEIF) {
     // added autorotate on load as currently it addresses orientation issues
     // https://github.com/libvips/libvips/pull/1680

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"image/png"
 	"math"
+	"os"
 	"runtime"
 	"unsafe"
 
@@ -229,7 +230,12 @@ func vipsLoadFromBuffer(buf []byte) (*C.VipsImage, ImageType, error) {
 		return nil, ImageTypeUnknown, ErrUnsupportedImageFormat
 	}
 
-	if err := C.load_image_buffer(unsafe.Pointer(&src[0]), C.size_t(len(src)), C.int(imageType), &out); err != 0 {
+	var unlimitedSvgLoad C.gboolean = C.FALSE
+	if _, exists := os.LookupEnv("UNLIMITED_SVG_LOAD"); exists {
+		unlimitedSvgLoad = C.TRUE
+	}
+
+	if err := C.load_image_buffer(unsafe.Pointer(&src[0]), C.size_t(len(src)), C.int(imageType), unlimitedSvgLoad, &out); err != 0 {
 		return nil, ImageTypeUnknown, handleImageError(out)
 	}
 

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -26,7 +26,7 @@ typedef enum types {
   BMP
 } ImageType;
 
-int load_image_buffer(void *buf, size_t len, int imageType, VipsImage **out);
+int load_image_buffer(void *buf, size_t len, int imageType, gboolean unlimitedSvgSize, VipsImage **out);
 
 typedef struct SaveParams {
   VipsImage *inputImage;


### PR DESCRIPTION
Support loading of big SVG files.
Issue: https://github.com/libvips/libvips/issues/1354
Func def: https://github.com/libvips/libvips/blob/15f4d935aad704818cb786413f6f90b29857b304/libvips/foreign/svgload.c#L775

